### PR TITLE
Опечатка в названии теста

### DIFF
--- a/tests/test_seconds_str.py
+++ b/tests/test_seconds_str.py
@@ -14,5 +14,5 @@ import tasks
     (93600, '01d02h00m00s'),
     (864000, '10d00h00m00s'),
 ])
-def test_prime(seconds, result):
+def test_seconds_to_str(seconds, result):
     assert tasks.seconds_to_str(seconds) == result


### PR DESCRIPTION
Тесты для разных заданий имеют одинаковые названия.
Вследствии чего неудобно запускать тесты, для каждого задания отдельно.
```bash
pytest -k test_name
```
